### PR TITLE
Fix bugged check button.

### DIFF
--- a/htmlxword/data/jstemplate.js
+++ b/htmlxword/data/jstemplate.js
@@ -27,7 +27,7 @@ function check() {
         if(word[4] == "down") {
             for (let j = 0; j < wordLen; j++) {
                 row = (startRow + j);
-                selector = "[row=\"" + row + "\"][column=\"" + startCol + "\"]";
+                selector = "input[row=\"" + row + "\"][column=\"" + startCol + "\"]";
                 inputField = document.querySelector(selector);
                 if (inputField.value.toUpperCase() != word[0][j]) {
                     window.confirm("Try again");
@@ -38,7 +38,7 @@ function check() {
         else {
             for (let j = 0; j < wordLen; j++) {
                 column = (startCol + j);
-                selector = "[row=\"" + startRow + "\"][column=\"" + column + "\"]";
+                selector = "input[row=\"" + startRow + "\"][column=\"" + column + "\"]";
                 inputField = document.querySelector(selector);
                 if (inputField.value.toUpperCase() != word[0][j]) {
                     window.confirm("Try again");


### PR DESCRIPTION
The issue is that recently row and column attributes were added to td elements and the input fields were being selected on just those attributes. This means td elements were being found where it was expected to be just input fields. I added input to the query selector of the javascript to ensure only inputs are selected.